### PR TITLE
Adding support for x64 Windows System

### DIFF
--- a/autoload/setup.py
+++ b/autoload/setup.py
@@ -1,6 +1,11 @@
 from distutils.core import setup, Extension
+import os, platform
 
-extSearch = Extension('fuzzycomt', ['fuzzycomt.c'], extra_compile_args=['-std=c99'])
+if os.name == 'nt' and platform.architecture()[0] == '64bit':
+    extSearch = Extension('fuzzycomt', ['fuzzycomt.c'], extra_compile_args=['-std=c99','-D MS_WIN64'])
+else:
+    extSearch = Extension('fuzzycomt', ['fuzzycomt.c'], extra_compile_args=['-std=c99'])
+
 
 
 setup (name = 'fuzzycomt',


### PR DESCRIPTION
Hi.
I don't if some else have the same problem but I can't compile.
I have this error.

```
build\temp.win-amd64-2.7\Release\fuzzycomt.o:fuzzycomt.c:(.text+0xaa0): undefined reference to `__imp_Py_InitModule4'
```

I have search on the web and found that adding "-D MS_WIN64" to the command resolve the problem. I have add this command to the setup.py and it's work.

I have automated that by adding some line into it.

Regards.
Jonathan Da Silva
