### PR TITLE
fix pattern issue

### DIFF
--- a/autoload/matcher.vim
+++ b/autoload/matcher.vim
@@ -93,7 +93,7 @@ fu! s:highlight(input, mmode, regex)
       " matchers instead)
       let pat = join(chars, '.\{-}')
       " Ensure we match the last version of our pattern
-      let ending = '\(.*'.pat.'\)\@!.*$'
+      let ending = '\(.*'.pat.'\)\@!'
       " Case insensitive
       let beginning = '\c^.*'
       if a:mmode == "filename-only"


### PR DESCRIPTION
The last `.*$` was too greedy, it would allow the last letter to match
and earlier occurrence. For example:

spec/spec_helper.rb when searching for spec would highlight the c
in the first spec, but the spe in the second spec.
With this, it highlights the whole second spec properly.
