### PR TITLE
Specifically build with Python 2.X.X

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pushd autoload
-python setup.py build
+python2 setup.py build
 pushd build/lib*
 cp fuzzycomt.so ../../
 popd


### PR DESCRIPTION
I'm running Python 3.3.4 on a flavour of Arch Linux which uses Python 3 by default. When building I'm presented with [a wall of warnings](https://asciinema.org/a/8158) and a failure to build / install.

This can be fixed by specifically building with the `python2` binary. I'm not sure if this could break other OSs though, it shouldn't. Being explicit should fix it for those OSs that use Python 3 by default.

The so is missing symbols when built with 3 by the looks of things.
