### PR TITLE
Remove bash build and install dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ There no real drawbacks, but i need to point out some things that may not work a
 
       First, get Python header files. Example for Debian/Ubuntu:
 
-      ```bash
+      ```sh
       [sudo] apt-get install python-dev
       ```
 
       Then run the installation script:
 
-      ```bash
-      cd ~/.vim/bundle/ctrlp-cmatcher/
+      ```sh
+      cd ~/.vim/bundle/ctrlp-cmatcher
       ./install.sh
       ```
 
@@ -43,15 +43,15 @@ There no real drawbacks, but i need to point out some things that may not work a
 
       First [fix the compiler](http://stackoverflow.com/a/22322645/6962):
 
-      ```bash
+      ```sh
       export CFLAGS=-Qunused-arguments
       export CPPFLAGS=-Qunused-arguments
       ```
 
       Then run the installation script:
 
-      ```bash
-      cd ~/.vim/bundle/ctrlp-cmatcher/
+      ```sh
+      cd ~/.vim/bundle/ctrlp-cmatcher
       ./install.sh
       ```
 
@@ -65,7 +65,7 @@ There no real drawbacks, but i need to point out some things that may not work a
 
       Then go to ``ctrlp-cmatcher`` dir and run the installation script:
 
-      ```bash
+      ```
       install_windows.bat
       ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There no real drawbacks, but i need to point out some things that may not work a
       cd ~/.vim/bundle/ctrlp-cmatcher/
       ./install.sh
       ```
-  
+
   * On Windows:
 
       Installation is similar to Linux version, but it can be more complicated becase of weird errors during compilation.

--- a/install.sh
+++ b/install.sh
@@ -1,43 +1,47 @@
-#! /usr/bin/env bash
+#!/usr/bin/env sh
+
 chkPython2()
 {
     cmd=$1
     ret=$($cmd -V 2>&1)
-    if [[ "$ret" == "Python 2."* ]]; then
+    case "$ret" in
+    "Python 2."*)
         return 0
-    else
+        ;;
+    *)
         return 1
-    fi
+        ;;
+    esac
 }
 
 findPython2()
 {
-    cmdlst=("python" "python2" "python27" "python2.7" "python26" "python2.6")
-    for cmd in "${cmdlst[@]}"; do
+    cmd_list="python python2 python27 python2.7 python26 python2.6"
+    for cmd in $cmd_list; do
         if chkPython2 $cmd; then
-            py=$cmd
+            found_python=$cmd
             break
         fi
     done
 
-    if [[ $py == "" ]]; then
+    if [ "$found_python" = "" ]; then
         echo "cannot find python2 automatically" >&2
         while true; do
-            read -p "please input your python2.* command: " cmd
+            read -p "please input your python 2 command: " cmd
             if chkPython2 "$cmd"; then
-                py=$cmd
+                found_python=$cmd
                 break
             fi
             echo "verify [$cmd] with -V failed" >&2
         done
     fi
 
-    echo "$py"
+    echo $found_python
 }
 
-py=$(findPython2)
-echo "find python2 -> $py"
+python=$(findPython2)
+echo "find python2 -> $python"
 
 cd autoload
-$py setup.py build
+$python setup.py build
 cp build/lib*/fuzzycomt.so .


### PR DESCRIPTION
#21 allowed to build and install on platforms not providing `bash'.

However, python program workarounds (#32) reintroduce this dependency.
We only need to run something like two commands, so building and
installing bash for this purpose is a little overkill, and I
appreciate the simplicity of just running `./install.sh` instead
of having to run the commands (even if simple) manually.

In addition, I renamed some variables to be more explicit, and updated
minor details in documentation.

I can of course make separate pull-requests for each commit if
preferred.
