### PR TITLE
Performance improvements

### DIFF
--- a/autoload/fuzzycomt.c
+++ b/autoload/fuzzycomt.c
@@ -163,7 +163,9 @@ double ctrlp_recursive_match(matchinfo_t *m,    // sharable meta-data
              j++, haystack_idx++) {
 
             char d = m->haystack_p[j];
-            if (d == '.') {
+            if (d == '\t' && mmode == firstNonTab) {
+                break;
+            } else if (d == '.') {
                 if (j == 0 || m->haystack_p[j - 1] == '/') {
                     m->dot_file = 1; // this is a dot-file
                 }

--- a/autoload/fuzzycomt.c
+++ b/autoload/fuzzycomt.c
@@ -60,9 +60,7 @@ void ctrlp_get_line_matches(PyObject* paths,
     // iterate over lines and get match score for every line
     for (i = 0, max = PyList_Size(paths); i < max; i++) {
         PyObject* path = PyList_GetItem(paths, i);
-        matchobj_t match;
-        match = ctrlp_find_match(path, abbrev, mmodeEnum);
-        matches[i] = match;
+        matches[i] = ctrlp_find_match(path, abbrev, mmodeEnum);
     }
 }
 

--- a/autoload/fuzzycomt.h
+++ b/autoload/fuzzycomt.h
@@ -28,6 +28,15 @@
 #include <string.h>
 #include <assert.h>
 
+
+
+typedef enum mmode {
+    fullLine,
+    filenameOnly,
+    firstNonTab,
+    untilLastTab
+} mmode_t;
+
 typedef struct {
     PyObject *str;                       // Python object with file path
     double  score;                       // score of string
@@ -43,7 +52,7 @@ typedef struct {
     double  *memo;                       // memoization
 } matchinfo_t;
 
-matchobj_t ctrlp_find_match(PyObject* str, PyObject* abbrev, char *mmode);
+matchobj_t ctrlp_find_match(PyObject* str, PyObject* abbrev, mmode_t mmode);
 
 void ctrlp_get_line_matches(PyObject* paths, PyObject* abbrev, matchobj_t matches[], char *mode);
 

--- a/autoload/matcher.vim
+++ b/autoload/matcher.vim
@@ -23,12 +23,18 @@ else
 endif
 
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
+" -----
+" PYTHON UNINDETED CODE BEGIN
+" -----
 python << ImportEOF
 import sys, os, vim
 sys.path.insert( 0, os.path.abspath( vim.eval('s:script_folder_path' ) ) )
 import fuzzycomt
 sys.path.pop(0)
 ImportEOF
+" -----
+" PYTHON UNINDETED CODE END
+" -----
 
 fu! s:matchtabs(item, pat)
   return match(split(a:item, '\t\+')[0], a:pat)
@@ -40,6 +46,9 @@ fu! s:matchfname(item, pat)
 endf
 
 fu! s:cmatcher(lines, input, limit, mmode, ispath, crfile)
+  " -----
+  " PYTHON UNINDETED CODE BEGIN
+  " -----
 python << EOF
 lines = vim.eval('a:lines')
 searchinp = vim.eval('a:input')
@@ -60,7 +69,10 @@ try:
 except:
   matchlist = []
 EOF
-return s:pyeval("matchlist")
+  " -----
+  " PYTHON UNINDETED CODE END
+  " -----
+  return s:pyeval("matchlist")
 endf
 
 fu! s:escapechars(chars)

--- a/autoload/matcher.vim
+++ b/autoload/matcher.vim
@@ -114,6 +114,11 @@ fu! s:highlight(input, mmode, regex)
         let beginning = beginning.'\([^\/]*$\)\@='
       end
 
+      if a:mmode == "first-non-tab"
+        " Make sure we stop at the tab
+        let ending = ending.'\t'
+      end
+
       for i in range(len(a:input))
         " Surround our current target letter with \zs and \ze so it only
         " actually matches that one letter, but has all preceding and trailing
@@ -169,21 +174,6 @@ fu! matcher#cmatch(lines, input, limit, mmode, ispath, crfile, regex)
       cal s:highlight(a:input, a:mmode, a:regex)
       return array
     endif
-    " use built-in matcher if mmode set to match until first tab ( in other case
-    " tag.vim doesnt work
-    if a:mmode == "first-non-tab"
-      let array = []
-      " call ctrlp.vim function to get proper input pattern
-      let pat = ctrlp#call('s:SplitPattern', a:input)
-      for item in a:lines
-        if call('s:matchtabs', [item, pat]) >= 0
-          cal add(array, item)
-        en
-      endfo
-      "TODO add highlight
-      cal sort(array, ctrlp#call('s:mixedsort'))
-      return array
-    en
 
     let matchlist = s:cmatcher(a:lines, a:input, a:limit, a:mmode, a:ispath, a:crfile)
   en


### PR DESCRIPTION
This makes a number of performance improvements avoiding largely copying and additional comparison.

The two most significant pieces are:
- re-arranging to avoid needing to allocate memory for splitslash
- switching to an enum for the mode
