### PR TITLE
Speed up matcher

### DIFF
--- a/autoload/fuzzycomt.c
+++ b/autoload/fuzzycomt.c
@@ -364,7 +364,7 @@ matchobj_t ctrlp_find_match(PyObject* str, PyObject* abbrev, char *mmode)
     temp_string = strduplicate(PyString_AsString(str));
 
     // Replace all backslashes
-    for (i = 0; i < strlen(temp_string); i++) {
+    for (i = 0; temp_string[i]; i++) {
         if (temp_string[i] == '\\') {
             temp_string[i] = '/';
         }


### PR DESCRIPTION
Speed up matching by ~30% by removing unnecessary call to strlen().

Before:
    2   0.225716   0.000183  matcher#cmatch()
After:
    2   0.163005   0.000214  matcher#cmatch()